### PR TITLE
- fix VS2017 compile error:

### DIFF
--- a/Client/Core/Client/CClient.cpp
+++ b/Client/Core/Client/CClient.cpp
@@ -20,7 +20,7 @@ CClient::CClient()
 	// Initialize game offsets
 	if(!CGameOffsets::Initialize())
 	{
-		MessageBox(NULL,"Cannot detect game version! Mod currently supports "MOD_SUPPORTED_VERSIONS" please try update or downgrade your game.","Fatal Error",MB_ICONERROR);
+		MessageBox(NULL,"Cannot detect game version! Mod currently supports " MOD_SUPPORTED_VERSIONS " please try update or downgrade your game.","Fatal Error",MB_ICONERROR);
 		ExitProcess(0);
 		return;
 	}


### PR DESCRIPTION
1>Client\CClient.cpp(23): error C3688: invalid literal suffix 'MOD_SUPPORTED_VERSIONS'; literal operator or literal operator template 'operator ""MOD_SUPPORTED_VERSIONS' not found
1>Client\CClient.cpp(23): error C2660: 'MessageBoxA': function does not take 3 arguments